### PR TITLE
Update Qoala_T_merge_example_script.R

### DIFF
--- a/Qoala_T_merge_example_script.R
+++ b/Qoala_T_merge_example_script.R
@@ -31,9 +31,10 @@ for (j in c("aparc_area_lh.txt","aparc_area_rh.txt","aparc_thickness_lh.txt","ap
   row.names(data) <- data[,1]
   data <- data[,-1]
   yourdatafile <- merge(yourdatafile,data,by="row.names",all.x=T)
+  yourdatafile <- yourdatafile[, -grep(".y|.x", colnames(yourdatafile))]
   row.names(yourdatafile) <- yourdatafile[,1]
   yourdatafile <- yourdatafile[,-1]
-}
+  }
 
 save(yourdatafile,file="yourdatafile.Rdata")
 


### PR DESCRIPTION
Added line to remove duplicate variables (i.e., sometimes eTIV variable is in all txt files, which gives an error message when merging)